### PR TITLE
Enhance market bot with adaptive price history analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 > - **Possível snipe/underpriced** (preço menor que a média histórica)
 > - **Possível fake BIN** (queda brusca sem confirmação de volume)
 > - **Spike de preço** (movimento forte que pode indicar flip)
+> - **Falhas de dados** preenchendo média e desvio automaticamente via histórico local
 
 Ele roda em loop 24/7 (enquanto o processo estiver ativo) e **envia alertas para um Webhook do Discord**.
 
@@ -30,6 +31,7 @@ Ele roda em loop 24/7 (enquanto o processo estiver ativo) e **envia alertas para
 4) **Configuração**
    - Copie `config.example.yaml` para `config.yaml` e ajuste caminhos/limiares.
    - Copie `.env.example` para `.env` e cole sua `DISCORD_WEBHOOK_URL`.
+   - Ajuste (se quiser) o bloco `history` para definir janela máxima, pontos e mínimo de amostras.
 
 5) **Instalar dependências**
 ```bash
@@ -63,6 +65,11 @@ player_id,name,rating,league,position,price,avg_price_24h,std_24h,updated_at
 - **Spike:** `price >= avg_24h * (1 + SPIKE_PCT)`
 
 Você pode editar limiares no `config.yaml`.
+
+### Histórico inteligente
+- Mantemos um **buffer circular em memória** com até 400 amostras recentes por jogador (configurável).
+- Quando `avg_price_24h` ou `std_24h` não vêm do feeder/scraper, eles são recalculados antes da análise.
+- Os alertas mostram quantas amostras sustentaram o cálculo (`Hist.: X pts`) para facilitar a confiança.
 
 ---
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -18,3 +18,9 @@ spike_pct: 0.20          # Alta >= 20% sinaliza spike
 # Alertas
 cooldown_minutes: 15     # Não repetir o mesmo alerta do mesmo jogador antes desse tempo
 notify_discord: true
+
+# Histórico interno (preenche média/desvio quando faltarem no CSV/scraper)
+history:
+  window_minutes: 1440   # janela de análise em minutos (padrão 24h)
+  max_points: 400        # máximo de pontos por jogador mantidos em memória
+  min_points: 3          # mínimo de pontos para usar as métricas calculadas

--- a/config.yaml
+++ b/config.yaml
@@ -14,3 +14,8 @@ fake_drop_pct: 0.40
 spike_pct: 0.20
 cooldown_minutes: 0
 notify_discord: false
+
+history:
+  window_minutes: 1440
+  max_points: 400
+  min_points: 3

--- a/storage/price_history.py
+++ b/storage/price_history.py
@@ -1,0 +1,96 @@
+"""In-memory helper to accumulate price history statistics."""
+from __future__ import annotations
+
+import math
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Deque, Dict, Optional, Tuple
+
+
+@dataclass
+class PriceStats:
+    """Aggregated metrics for a player's price history."""
+
+    average: float
+    stddev: float
+    count: int
+
+
+@dataclass
+class PriceHistory:
+    """Maintain rolling price histories per player."""
+
+    window_minutes: int = 60 * 24
+    max_points: int = 400
+    _data: Dict[str, Deque[Tuple[float, float]]] = field(default_factory=dict, init=False)
+
+    def __post_init__(self) -> None:
+        self.window_seconds = max(60, int(self.window_minutes) * 60)
+        self.max_points = max(10, int(self.max_points))
+
+    def _normalise_timestamp(self, value: object | None) -> float:
+        if isinstance(value, (int, float)):
+            return float(value)
+        if isinstance(value, datetime):
+            if value.tzinfo is None:
+                value = value.replace(tzinfo=timezone.utc)
+            return value.timestamp()
+        if isinstance(value, str) and value:
+            text = value.strip()
+            if text.endswith("Z"):
+                text = text[:-1] + "+00:00"
+            try:
+                dt = datetime.fromisoformat(text)
+            except ValueError:
+                return time.time()
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt.timestamp()
+        return time.time()
+
+    def _trim(self, series: Deque[Tuple[float, float]], now: float) -> None:
+        cutoff = now - self.window_seconds
+        while series and series[0][0] < cutoff:
+            series.popleft()
+        while len(series) > self.max_points:
+            series.popleft()
+
+    def add(self, player_id: str, price: float, updated_at: object | None = None) -> None:
+        """Add a new price sample for ``player_id``."""
+
+        ts = self._normalise_timestamp(updated_at)
+        series = self._data.setdefault(player_id, deque())
+        series.append((ts, float(price)))
+        self._trim(series, ts)
+
+    def get_stats(self, player_id: str) -> Optional[PriceStats]:
+        """Return aggregated stats for ``player_id`` within the window."""
+
+        series = self._data.get(player_id)
+        if not series:
+            return None
+
+        now = time.time()
+        self._trim(series, now)
+        if not series:
+            return None
+
+        prices = [price for _, price in series]
+        count = len(prices)
+        if not count:
+            return None
+
+        avg = sum(prices) / count
+        if count == 1:
+            stddev = 0.0
+        else:
+            variance = sum((price - avg) ** 2 for price in prices) / count
+            stddev = math.sqrt(variance)
+        return PriceStats(average=avg, stddev=stddev, count=count)
+
+    def clear(self) -> None:
+        """Remove all cached history."""
+
+        self._data.clear()


### PR DESCRIPTION
## Summary
- add an in-memory price history engine that backfills averages/standard deviation when the data source omits them
- expose configurable history settings and surface history coverage in alert messages and documentation
- improve numeric parsing/rounding so alerts are more robust to formatted prices

## Testing
- python -m compileall main.py storage/price_history.py

------
https://chatgpt.com/codex/tasks/task_e_68e040bde2f08326ba34cc58bff0d30d