### PR TITLE
Improve Futwiz scraping robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ O bot vai realizar scraping periódico do Futwiz e enviar alertas quando detecta
 - `platform`: `ps` | `xbox` | `pc`
 - `pages`: quantas páginas do grid do Futwiz serão varridas por rodada
 - `delay_between_pages`: pausa (segundos) entre cada requisição para evitar bloqueios
+- `delay_jitter`: ruído aleatório aplicado ao delay para humanizar o tráfego
+- `timeout`: tempo limite (segundos) para cada request antes de abortar
+- `max_retries` + `backoff_factor`: tentativas automáticas com backoff exponencial para erros HTTP/429
+- `extra_headers`: cabeçalhos HTTP extras (ex.: `Accept-Language`) aplicados em todas as requisições
+- `proxies`: proxies HTTP/S caso precise distribuir o scraping em outra rota
 
 ### Detectores
 - **Underpriced/Snipe:** `price <= avg_24h * (1 - min_discount)` **e** `zscore <= -zscore_min`

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -3,6 +3,12 @@ futwiz:
   platform: ps                               # ps | xbox | pc
   pages: 1                                   # número de páginas do grid para scrapear
   delay_between_pages: 1.0                   # pausa entre requisições em segundos
+  delay_jitter: 0.3                          # variação aleatória (0.3 -> +/-0.3s)
+  timeout: 15                                # timeout da requisição HTTP em segundos
+  max_retries: 3                             # tentativas em caso de erro/transient block
+  backoff_factor: 0.6                        # fator exponencial entre tentativas
+  extra_headers: {}                          # cabeçalhos extras (ex.: Accept-Language)
+  proxies: {}                                # proxies HTTP/S se precisar rotear tráfego
 
 poll_interval_secs: 20                       # Freq. que verificamos/refresh
 

--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,12 @@ futwiz:
   platform: ps
   pages: 1
   delay_between_pages: 1.0
+  delay_jitter: 0.3
+  timeout: 15
+  max_retries: 3
+  backoff_factor: 0.6
+  extra_headers: {}
+  proxies: {}
 
 poll_interval_secs: 5
 min_discount: 0.12

--- a/main.py
+++ b/main.py
@@ -28,6 +28,12 @@ class Config:
     futwiz_platform: str
     futwiz_pages: int
     futwiz_delay_between_pages: float
+    futwiz_delay_jitter: float
+    futwiz_timeout: float
+    futwiz_max_retries: int
+    futwiz_backoff_factor: float
+    futwiz_extra_headers: Dict[str, str]
+    futwiz_proxies: Dict[str, str]
     history_window_minutes: int
     history_max_points: int
     history_min_points: int
@@ -52,6 +58,12 @@ def load_config() -> Config:
         futwiz_platform=str(futwiz_cfg.get("platform", "ps")),
         futwiz_pages=int(futwiz_cfg.get("pages", 1)),
         futwiz_delay_between_pages=float(futwiz_cfg.get("delay_between_pages", 1.0)),
+        futwiz_delay_jitter=float(futwiz_cfg.get("delay_jitter", 0.0)),
+        futwiz_timeout=float(futwiz_cfg.get("timeout", 15.0)),
+        futwiz_max_retries=int(futwiz_cfg.get("max_retries", 3)),
+        futwiz_backoff_factor=float(futwiz_cfg.get("backoff_factor", 0.5)),
+        futwiz_extra_headers=dict(futwiz_cfg.get("extra_headers", {}) or {}),
+        futwiz_proxies=dict(futwiz_cfg.get("proxies", {}) or {}),
         history_window_minutes=max(1, int(history_cfg.get("window_minutes", 60 * 24))),
         history_max_points=max(10, int(history_cfg.get("max_points", 400))),
         history_min_points=max(1, int(history_cfg.get("min_points", 3))),
@@ -161,6 +173,12 @@ def run():
         platform=cfg.futwiz_platform,
         pages=cfg.futwiz_pages,
         delay_between_pages=cfg.futwiz_delay_between_pages,
+        delay_jitter=cfg.futwiz_delay_jitter,
+        timeout=cfg.futwiz_timeout,
+        max_retries=cfg.futwiz_max_retries,
+        backoff_factor=cfg.futwiz_backoff_factor,
+        extra_headers=cfg.futwiz_extra_headers,
+        proxies=cfg.futwiz_proxies,
     )
 
     while True:


### PR DESCRIPTION
## Summary
- add retry/backoff, configurable headers/proxies, jitter and smarter parsing to the Futwiz scraper
- expose the new scraper controls through the YAML config and document them in the README

## Testing
- python -m compileall main.py sources

------
https://chatgpt.com/codex/tasks/task_e_68e04b1d9b6483269767a8d24ded9619